### PR TITLE
Fix daily-log-agent directory handling

### DIFF
--- a/agents/daily-log-agent.md
+++ b/agents/daily-log-agent.md
@@ -13,6 +13,12 @@ You are a specialized daily log agent that autonomously executes the daily log w
 - Determine role distribution from actual collaboration patterns observed
 - Generate "What We Accomplished" from concrete work completed
 
+**Directory Handling (CRITICAL FIRST STEP):**
+- Always cd to ~/.claude directory before any file operations
+- Verify ~/.claude directory exists, handle gracefully if missing
+- All file paths are relative to ~/.claude (daily-logs/YYYY/YYYY-MM.md)
+- Return to original directory only after all operations complete
+
 **File Operations:**
 - Determine current monthly file path (daily-logs/YYYY/YYYY-MM.md)
 - Check if today's date section exists, create if needed

--- a/commands/daily-log.md
+++ b/commands/daily-log.md
@@ -17,7 +17,25 @@ Daily logs are now organized in the repository under `daily-logs/` directory:
 
 ## Process
 
-### Branch Safety Check (Always First)
+### Directory Setup (Always First)
+```bash
+# Ensure we're working in the ~/.claude directory
+claude_dir="$HOME/.claude"
+if [[ ! -d "$claude_dir" ]]; then
+  echo "❌ ~/.claude directory not found"
+  echo "Please ensure the claude-config repository is cloned to ~/.claude"
+  exit 1
+fi
+
+# Change to ~/.claude directory for all operations
+cd "$claude_dir" || {
+  echo "❌ Failed to change to ~/.claude directory"
+  exit 1
+}
+echo "📁 Working in ~/.claude directory"
+```
+
+### Branch Safety Check
 ```bash
 # Check if we're on main/master branch
 current_branch=$(git branch --show-current)


### PR DESCRIPTION
## Summary
- Fix daily-log-agent directory handling issue where agent incorrectly assumed current working directory
- Add explicit directory setup step to ensure operations happen in ~/.claude
- Add error handling for missing ~/.claude directory

## Changes Made
- **Daily Log Agent** (`agents/daily-log-agent.md`):
  - Added "Directory Handling" section with explicit ~/.claude requirement
  - Updated file operations to assume ~/.claude working directory
- **Daily Log Command** (`commands/daily-log.md`):
  - Added directory setup step before branch safety checks
  - Verify ~/.claude exists with clear error messages
  - Automatically cd to ~/.claude for all operations

## Test Plan
- [x] Verified absolute path access works from any directory (`~/.claude/daily-logs/...`)
- [x] Verified relative path access works when in ~/.claude directory (`daily-logs/...`)
- [x] Confirmed changes follow existing command structure and safety checks
- [x] Git workflow tested successfully

## Fixes
Closes #14

🤖 Generated with [Claude Code](https://claude.ai/code)