### PR TITLE
feat: add /pr-audit slash command

### DIFF
--- a/pr-audit.md
+++ b/pr-audit.md
@@ -1,0 +1,49 @@
+# PR Audit Command
+
+You are conducting a comprehensive audit of open pull requests that need review attention.
+
+## Instructions
+
+1. **Get all open PRs** using GitHub CLI with detailed information
+2. **Filter and categorize** PRs based on review status:
+   - Non-draft PRs requiring initial review (reviewDecision: "REVIEW_REQUIRED")
+   - PRs with requested changes (reviewDecision: "CHANGES_REQUESTED") 
+   - Exclude approved PRs, drafts, and dependabot PRs
+3. **Create organized output** with clickable links and key details
+
+## Output Format
+
+Create a structured markdown list with:
+- **Priority PRs Needing Review** (non-draft, no review yet)
+- **PRs Awaiting Changes** (have feedback, need author action)
+- **Summary statistics**
+
+## Commands to Run
+
+```bash
+gh pr list --state open --json number,title,author,isDraft,reviewDecision,url,headRefName --limit 50
+```
+
+## Filtering Logic
+
+- Include: `isDraft: false` AND `reviewDecision: "REVIEW_REQUIRED"`
+- Include: `reviewDecision: "CHANGES_REQUESTED"` 
+- Exclude: `isDraft: true`
+- Exclude: `reviewDecision: "APPROVED"`
+- Exclude: `author.login: "app/dependabot"`
+
+## Output Template
+
+```markdown
+## 🔍 Open PRs Needing Review
+
+**Non-draft PRs requiring review:**
+- [#XXXX - Title](URL) by Author
+
+**PRs with requested changes:**
+- [#XXXX - Title](URL) by Author
+
+**Total: X PRs requiring initial review + Y PRs needing changes addressed**
+```
+
+Focus on actionable PRs that team members can immediately review or that authors need to update.


### PR DESCRIPTION
## Summary
Adds a new `/pr-audit` slash command for systematically reviewing open pull requests that need attention.

## Features
- **Comprehensive PR filtering**: Identifies non-draft PRs requiring review
- **Status categorization**: Separates PRs needing initial review from those awaiting changes
- **Clean output format**: Structured markdown with clickable links
- **Smart exclusions**: Filters out approved PRs, drafts, and dependabot PRs

## Usage
Run `/pr-audit` in any Claude conversation to get an organized list of PRs requiring review attention.

## Implementation
- Uses GitHub CLI to fetch PR data with review status
- Applies filtering logic to focus on actionable PRs
- Outputs structured markdown for easy navigation

This will help streamline the PR review process by providing a quick overview of what needs attention.