### PR TITLE
chore: add skills directory to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,9 @@ file-history/
 history.jsonl
 
 # Skills (contains org-specific data)
-skills/
+skills/*/
+!skills/README.md
+!skills/examples/
 
 # Cache and temporary files
 *.cache

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,39 @@
+# Claude Code Skills
+
+This directory contains custom [Claude Code Skills](https://code.claude.com/docs/en/skills) - modular capabilities that Claude automatically loads when relevant.
+
+## What Are Skills?
+
+Skills are model-invoked (Claude decides when to use them based on context) vs slash commands which are user-invoked. Each skill is a folder containing a `SKILL.md` file with YAML frontmatter.
+
+## Available Skills
+
+| Skill | Description |
+|-------|-------------|
+| `shortcut-teams` | Static reference for Shortcut team UUIDs - prevents repeated API calls |
+| `daily-log` | Reliable daily log management with correct file paths and templates |
+
+## Creating Your Own Skills
+
+1. Create a folder: `~/.claude/skills/your-skill-name/`
+2. Add a `SKILL.md` file with required frontmatter
+3. Claude will auto-discover and use it when relevant
+
+### Required Structure
+
+```markdown
+---
+name: your-skill-name
+description: Brief description of when Claude should use this skill.
+---
+
+# Your Skill Title
+
+Content and instructions here...
+```
+
+## Why Skills Are Gitignored
+
+Skills in this directory often contain org-specific data (team IDs, user IDs, internal URLs) that shouldn't be committed to version control. Each user should create their own skills with their org's data.
+
+See `examples/` for templates you can copy and customize.

--- a/skills/examples/daily-log.example.md
+++ b/skills/examples/daily-log.example.md
@@ -1,0 +1,107 @@
+---
+name: daily-log
+description: Reliable daily log management for development sessions. Use this skill when adding session entries to daily logs to ensure correct file paths and formatting.
+---
+
+# Daily Log Management
+
+## File Path Convention
+
+Daily logs are stored at: `~/.claude/daily-logs/YYYY/YYYY-MM.md`
+
+Example: December 2025 logs are at `~/.claude/daily-logs/2025/2025-12.md`
+
+## Adding Log Entries - Step by Step
+
+1. **Determine the file path:**
+   ```
+   ~/.claude/daily-logs/YYYY/YYYY-MM.md
+   ```
+   Use current year and month (e.g., `2025/2025-12.md`)
+
+2. **Check if date heading exists:**
+   - Search for `## YYYY-MM-DD` in the file
+   - If found, append new session under it (separated by `---`)
+   - If not found, add the heading at the end of the file
+
+3. **Use the session template below**
+
+4. **Multiple sessions same day:**
+   - Separate with `---` horizontal rule
+   - Each session gets its own "Session Overview" block
+
+## Session Template
+
+```markdown
+## YYYY-MM-DD
+
+### Session Overview
+**Duration:** [time]
+**Main Objective:** [objective]
+**Success Rating:** [X]/10
+
+### What We Accomplished
+- [bullet points]
+
+### Challenges Encountered
+- [bullet points or "None"]
+
+### Most Valuable Collaboration
+[description]
+
+### Key Insight
+[main learning]
+
+### Follow-Up Items
+- [ ] [action items]
+
+### Role Distribution
+**Human:** [role]
+**Claude:** [role]
+
+### Success Factors
+[what made it successful, if rating 6+]
+
+---
+```
+
+## Questions to Ask User
+
+1. What was the main objective for today's session?
+2. How long did we work together today?
+3. What was your role/involvement? (directing, collaborating, reviewing)
+4. What specific challenges did we encounter?
+5. What was the most valuable part of our collaboration?
+6. Any lessons learned or insights to document?
+7. Any follow-up items for future sessions?
+8. How would you rate overall success? (1-10)
+
+## Bash Script for File Management
+
+```bash
+#!/bin/bash
+YEAR=$(date +%Y)
+MONTH=$(date +%m)
+TODAY=$(date +%Y-%m-%d)
+LOG_DIR="$HOME/.claude/daily-logs/$YEAR"
+LOG_FILE="$LOG_DIR/$YEAR-$MONTH.md"
+
+mkdir -p "$LOG_DIR"
+
+if [ ! -f "$LOG_FILE" ]; then
+  MONTH_NAME=$(date +%B)
+  echo "# Daily Logs - $MONTH_NAME $YEAR" > "$LOG_FILE"
+  echo "" >> "$LOG_FILE"
+fi
+
+echo "Log file: $LOG_FILE"
+echo "Today's date heading: ## $TODAY"
+```
+
+## Customization
+
+Adjust the template sections to match your workflow. Common additions:
+- Links to PRs/issues worked on
+- Screenshots or diagrams
+- Code snippets worth remembering
+- Meeting notes or decisions made

--- a/skills/examples/shortcut-teams.example.md
+++ b/skills/examples/shortcut-teams.example.md
@@ -1,0 +1,46 @@
+---
+name: shortcut-teams
+description: Static reference for Shortcut team UUIDs and mention names. Use this when creating or assigning Shortcut stories instead of querying the API for team lists.
+---
+
+# Shortcut Teams Reference
+
+Use these UUIDs when creating or assigning Shortcut stories. **Do not query the API for team lists** - use this reference directly.
+
+## How to Populate This File
+
+Run this command to get your teams, then copy the relevant data here:
+
+```bash
+# Using the Shortcut MCP tool
+mcp__shortcut__teams-list
+```
+
+Or use the Shortcut API directly:
+
+```bash
+curl -s -H "Shortcut-Token: $SHORTCUT_API_TOKEN" \
+  "https://api.app.shortcut.com/api/v3/teams" | jq '.[] | {name, id, mention_name}'
+```
+
+## Commonly Used Teams
+
+| Team Name | UUID | Mention Name |
+|-----------|------|--------------|
+| Example Team | `xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx` | `@example-team` |
+| Another Team | `yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy` | `@another-team` |
+
+## All Active Teams
+
+<!-- Add your full team list here -->
+
+| Team Name | UUID | Mention Name |
+|-----------|------|--------------|
+| ... | `...` | `@...` |
+
+## Your User Information
+
+- **Name:** Your Name
+- **Mention:** `@your-mention-name`
+- **UUID:** `your-user-uuid`
+- **Team Memberships:** List your teams here


### PR DESCRIPTION
## Summary
- Adds `skills/` directory to `.gitignore` to prevent committing org-specific data
- Skills are created locally using Claude Code's [Skills feature](https://code.claude.com/docs/en/skills)
- Contains Shortcut team UUIDs and user IDs that should remain local

## What's Included Locally (not committed)
- `skills/shortcut-teams/SKILL.md` - Static reference for Shortcut team UUIDs
- `skills/daily-log/SKILL.md` - Reliable daily log management script

## How Skills Work
Skills are model-invoked - Claude automatically loads them when relevant based on the description in the YAML frontmatter.

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)