### PR TITLE
chore: gitignore personality runtime files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,10 @@ tasks/
 # Skills manifest (local state)
 .claude-skills-manifest.json
 
+# Personality runtime files
+statusline-command.sh
+settings.local.json
+
 # Local config and backups
 *.bak
 mcp_config_template.json


### PR DESCRIPTION
## Summary
- Adds `statusline-command.sh` and `settings.local.json` to `.gitignore`
- These files are generated by personality swaps and always show as dirty

## Test plan
- [x] Verify files no longer appear in `git status`

🤖 Generated with [Claude Code](https://claude.com/claude-code)